### PR TITLE
Fluent endpoint DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ end
 
 The swagger json endpoint will be exposed at `/swagger_doc.json`.
 
+You can also use a more fluent variant by providing a hash to the `endpoint` method
+
+
+```ruby
+  endpoint :description => 'Base method to ping',
+           :response [200, 'Status', 'Standard response']
+           :tags 'Ping'
+  get '/' do
+    json({'status' => 'OK'})
+  end
+```
+
+The hash should contains the key `description`, `summary`, `response`, `tags`, and `responses` which takes a `hash(param_name =>param_details)`
+
+If the equivalent methods have more than one param, theses are wrapped in an array.
+
+
 ## Detailed example
 
 A more complete example is available [here](https://github.com/archiloque/sinatra-swagger-exposer/tree/master/example).

--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ You can also use a more fluent variant by providing a hash to the `endpoint` met
 
 ```ruby
   endpoint :description => 'Base method to ping',
-           :response [200, 'Status', 'Standard response']
+           :responses { 200 => ['Status', 'Standard response']}
            :tags 'Ping'
   get '/' do
     json({'status' => 'OK'})
   end
 ```
 
-The hash should contains the key `description`, `summary`, `response`, `tags`, and `responses` which takes a `hash(param_name =>param_details)`
+The hash should contains the key `description`, `summary`, `path`, `tags`, `responses` and `params`.
+Note both `responses` and `params` takes a hash as argument `hash(param_name =>param_details)` and `hash(status_code=>res_param)`
 
 If the equivalent methods have more than one param, theses are wrapped in an array.
 

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -78,6 +78,29 @@ module Sinatra
           settings.swagger_types.keys)
     end
 
+    # Define fluent endpoint dispatcher
+    def endpoint(params)
+      if params[:summary]
+        endpoint_summary params[:summary]
+      end
+      if params[:description]
+        endpoint_description params[:description]
+      end
+      if params[:response]
+        endpoint_response *params[:response]
+      end
+      if params[:tags]
+        endpoint_tags *params[:tags]
+      end
+      if params[:parameters]
+        params[:parameters].each do |param, args|
+          endpoint_parameter param, *args
+        end
+      end
+
+    end
+
+
     # General information
     def general_info(params)
       set :swagger_info, SwaggerInfo.new(params)

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -84,6 +84,7 @@ module Sinatra
       endpoint_summary params[:summary] if params[:summary]
       endpoint_description params[:description] if params[:description]
       endpoint_tags *params[:tags] if params[:tags]
+      endpoint_path *params[:path] if params[:path]
 
       if params[:parameters]
         params[:parameters].each do |param, args|

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -80,20 +80,24 @@ module Sinatra
 
     # Define fluent endpoint dispatcher
     def endpoint(params)
-
-      endpoint_summary params[:summary] if params[:summary]
-      endpoint_description params[:description] if params[:description]
-      endpoint_tags *params[:tags] if params[:tags]
-      endpoint_path *params[:path] if params[:path]
-
-      if params[:parameters]
-        params[:parameters].each do |param, args|
-          endpoint_parameter param, *args
-        end
-      end
-      if params[:responses]
-        params[:responses].each do |code, args|
-          endpoint_response code, *args
+      params.each_pair do |param, args|
+        case param
+          when :summary
+            endpoint_summary args
+          when :description
+            endpoint_description args
+          when :tags
+            endpoint_tags *args
+          when :path
+            endpoint_path args
+          when :parameters
+            args.each do |param, args_param|
+              endpoint_parameter param, *args_param
+            end
+          when :responses
+            args.each do |code, args_response|
+              endpoint_response code, *args_response
+            end
         end
       end
     end

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -80,26 +80,16 @@ module Sinatra
 
     # Define fluent endpoint dispatcher
     def endpoint(params)
-      if params[:summary]
-        endpoint_summary params[:summary]
-      end
-      if params[:description]
-        endpoint_description params[:description]
-      end
-      if params[:response]
-        endpoint_response *params[:response]
-      end
-      if params[:tags]
-        endpoint_tags *params[:tags]
-      end
-      if params[:parameters]
-        params[:parameters].each do |param, args|
-          endpoint_parameter param, *args
-        end
-      end
 
+      endpoint_summary params[:summary] if params[:summary]
+      endpoint_description params[:description] if params[:description]
+      endpoint_response *params[:response] if params[:response]
+      endpoint_tags *params[:tags] if params[:tags]
+
+      params[:parameters].each do |param, args|
+        endpoint_parameter param, *args
+      end if params[:parameters]
     end
-
 
     # General information
     def general_info(params)

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -83,12 +83,18 @@ module Sinatra
 
       endpoint_summary params[:summary] if params[:summary]
       endpoint_description params[:description] if params[:description]
-      endpoint_response *params[:response] if params[:response]
       endpoint_tags *params[:tags] if params[:tags]
 
-      params[:parameters].each do |param, args|
-        endpoint_parameter param, *args
-      end if params[:parameters]
+      if params[:parameters]
+        params[:parameters].each do |param, args|
+          endpoint_parameter param, *args
+        end
+      end
+      if params[:responses]
+        params[:responses].each do |code, args|
+          endpoint_response code, *args
+        end
+      end
     end
 
     # General information

--- a/test/test-swagger-exposer.rb
+++ b/test/test-swagger-exposer.rb
@@ -317,6 +317,11 @@ class TestSwaggerExposer < Minitest::Test
           sum.must_equal 'hello'
         end
 
+        def self.endpoint_path(sum)
+          @@cal_counter+=1
+          sum.must_equal '/the-path'
+        end
+
         def self.endpoint_description(desc)
           @@cal_counter+=1
           desc.must_equal 'Base method to ping'
@@ -344,7 +349,7 @@ class TestSwaggerExposer < Minitest::Test
         end
 
         def self.all_called
-          @@cal_counter == 6
+          @@cal_counter == 7
         end
 
         type 'status', {}
@@ -352,6 +357,7 @@ class TestSwaggerExposer < Minitest::Test
                  :description => 'Base method to ping',
                  :responses => {200 =>[ 'Status', 'Standard response']},
                  :tags => 'Ping',
+                 :path => '/the-path',
                  :parameters => {'plop' => ['description', :body, true, String],
                                  'plip' => ['description', :body, true, String]}
         get '/path' do

--- a/test/test-swagger-exposer.rb
+++ b/test/test-swagger-exposer.rb
@@ -304,6 +304,64 @@ class TestSwaggerExposer < Minitest::Test
       last_response.body.must_equal '999'
     end
 
+    it 'Should handle fluent endpoint' do
+
+      class MySinatraApp_RegisterFluentEndpoint < Sinatra::Base
+        register Sinatra::SwaggerExposer
+
+        @@cal_counter=0
+
+        # Mock Expectation
+        def self.endpoint_summary(sum)
+          @@cal_counter+=1
+          sum.must_equal 'hello'
+        end
+
+        def self.endpoint_description(desc)
+          @@cal_counter+=1
+          sum.must_equal 'Base method to ping'
+        end
+
+        def self.endpoint_response(code, type = nil, description = nil)
+          @@cal_counter+=1
+          code.must_equal 200
+          type.must_equal 'Status'
+          description.must_equal 'Standard response'
+        end
+
+        def self.endpoint_parameter(name, description, how_to_pass, required, type, params = {})
+          @@cal_counter+=1
+          name.must_match /pl.p/
+          description.must_equal 'description'
+          how_to_pass.must_equal :body
+          required.must_be true
+          type.must_be_same_as String
+        end
+
+        def self.endpoint_tags(*tags)
+          tags.first.must_equal 'Ping'
+          @@cal_counter+=1
+        end
+
+        def self.all_called
+          @@cal_counter == 6
+        end
+
+        type 'status', {}
+        endpoint :summary => 'hello',
+                 :description => 'Base method to ping',
+                 :response => [200, 'Status', 'Standard response'],
+                 :tags => 'Ping',
+                 :parameters => {'plop' => ['description', :body, true, String],
+                                 'plip' => ['description', :body, true, String]}
+        get '/path' do
+          200
+        end
+      end
+      MySinatraApp_RegisterFluentEndpoint.all_called.must_be true
+    end
+
+    it 'Should handle fluent endpoint with many tags'
 
   end
 

--- a/test/test-swagger-exposer.rb
+++ b/test/test-swagger-exposer.rb
@@ -350,7 +350,7 @@ class TestSwaggerExposer < Minitest::Test
         type 'status', {}
         endpoint :summary => 'hello',
                  :description => 'Base method to ping',
-                 :response => [200, 'Status', 'Standard response'],
+                 :responses => {200 =>[ 'Status', 'Standard response']},
                  :tags => 'Ping',
                  :parameters => {'plop' => ['description', :body, true, String],
                                  'plip' => ['description', :body, true, String]}

--- a/test/test-swagger-exposer.rb
+++ b/test/test-swagger-exposer.rb
@@ -319,7 +319,7 @@ class TestSwaggerExposer < Minitest::Test
 
         def self.endpoint_description(desc)
           @@cal_counter+=1
-          sum.must_equal 'Base method to ping'
+          desc.must_equal 'Base method to ping'
         end
 
         def self.endpoint_response(code, type = nil, description = nil)
@@ -334,7 +334,7 @@ class TestSwaggerExposer < Minitest::Test
           name.must_match /pl.p/
           description.must_equal 'description'
           how_to_pass.must_equal :body
-          required.must_be true
+          required.must_equal true
           type.must_be_same_as String
         end
 
@@ -358,7 +358,7 @@ class TestSwaggerExposer < Minitest::Test
           200
         end
       end
-      MySinatraApp_RegisterFluentEndpoint.all_called.must_be true
+      MySinatraApp_RegisterFluentEndpoint.all_called.must_equal true
     end
 
     it 'Should handle fluent endpoint with many tags'


### PR DESCRIPTION
Introduce a fluet _DSL_ to describe the `endpoint` with just one method call taking a hash of parameters
