### PR TITLE
Added support for operationId on endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ Note both `responses` and `params` takes a hash as argument `hash(param_name =>p
 
 If the equivalent methods have more than one param, theses are wrapped in an array.
 
+## Integration with swagger-js
+
+[Swagger-js](https://github.com/swagger-api/swagger-js) is a javascript
+library to automatically generate clients for swagger-enabled APIs. 
+Swagger-js uses the `tag` and the `operation_id` of an operation to
+generate the javascript methods on the client. 
+
+Thus, in your sinatra-application, use the following code:
+
+```ruby
+  endpoint_tag 'cat'
+  endpoint_operation_id 'findCatByName'
+  get '/cat' do
+    # code goes here
+  end
+```
+
+Now, you can use the client in javascript:
+
+```javascript
+  client = new SwaggerClient(...)
+  client.cat.findCatByName(...)
+```
 
 ## Detailed example
 

--- a/example/petstore.rb
+++ b/example/petstore.rb
@@ -104,6 +104,7 @@ class Petstore < Sinatra::Base
 
   endpoint_summary 'Finds all the pets'
   endpoint_description 'Returns all pets from the system that the user has access to'
+  endpoint_operation_id 'findPets'
   endpoint_tags 'Pets'
   endpoint_response 200, ['Pet'], 'Standard response', ['X-Total-Count']
   endpoint_parameter :size, 'The number of pets to return', :query, false, Integer,
@@ -120,6 +121,7 @@ class Petstore < Sinatra::Base
   end
 
   endpoint_summary 'Create a pet'
+  endpoint_operation_id 'addPet'
   endpoint_tags 'Pets'
   endpoint_response 200, 'Pet', 'Standard response'
   endpoint_parameter :name, 'The pet name', :body, true, String, {
@@ -139,6 +141,7 @@ class Petstore < Sinatra::Base
 
   endpoint_summary 'Finds all the cats'
   endpoint_description 'Returns all cats from the system that the user has access to'
+  endpoint_operation_id 'findCats'
   endpoint_tags 'Cats'
   endpoint_response 200, ['Cat'], 'Standard response'
   endpoint_parameter :size, 'The number of cats to return', :query, false, Integer,
@@ -156,6 +159,7 @@ class Petstore < Sinatra::Base
 
   endpoint_summary 'Finds a pet by its id'
   endpoint_description 'Finds a pet by its id, or 404 if the user does not have access to the pet'
+  endpoint_operation_id 'getPetById'
   endpoint_tags 'Pets'
   endpoint_response 200, 'Pet', 'Standard response'
   endpoint_response 404, 'Error', 'Pet not found'
@@ -171,6 +175,7 @@ class Petstore < Sinatra::Base
 
   endpoint_summary 'Get a pet image'
   endpoint_description 'Get a pet image from its id'
+  endpoint_operation_id 'getPetImageById'
   endpoint_tags 'Pets'
   endpoint_produces 'image/gif', 'application/json'
   endpoint_response 200, 'file', 'Standard response'
@@ -192,6 +197,7 @@ class Petstore < Sinatra::Base
   end
 
   endpoint_summary 'Create a cat'
+  endpoint_operation_id 'createCat'
   endpoint_tags 'Cats'
   endpoint_response 200, 'CatRoot', 'Standard response'
   endpoint_parameter :cat, 'The cat', :body, true, 'CatRoot'

--- a/lib/sinatra/swagger-exposer/configuration/swagger-endpoint.rb
+++ b/lib/sinatra/swagger-exposer/configuration/swagger-endpoint.rb
@@ -24,7 +24,8 @@ module Sinatra
         # @param tags [Array<String>] a list of tags
         # @param explicit_path [String] an explicit path if the sinatra path is a regex
         # @param produces [Array<String>] the result types
-        def initialize(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces)
+        # @param operationId [String] an operation id for the endpoint
+        def initialize(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces, operation_id)
           @type = type
           @path = swagger_path(sinatra_path, explicit_path)
 
@@ -44,6 +45,9 @@ module Sinatra
           end
           if produces
             @attributes[:produces] = produces
+          end
+          if operation_id
+            @attributes[:operationId] = operation_id
           end
         end
 

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -91,6 +91,12 @@ module Sinatra
       set_if_not_exist(produces, :produces)
     end
 
+    # Provide an operationId for the endpoint
+    # @param operation_id, [String] the operationId
+    def endpoint_operation_id(operation_id)
+      set_if_type_and_not_exist(operation_id, :operation_id, String)
+    end
+
     # Define parameter for the endpoint
     def endpoint_parameter(name, description, how_to_pass, required, type, params = {})
       parameters = settings.swagger_current_endpoint_parameters
@@ -120,6 +126,8 @@ module Sinatra
             endpoint_produces *param_value
           when :path
             endpoint_path param_value
+          when :operation_id
+            endpoint_operation_id param_value
           when :parameters
             param_value.each do |param, args_param|
               endpoint_parameter param, *args_param
@@ -221,7 +229,8 @@ module Sinatra
         current_endpoint_info[:description],
         current_endpoint_info[:tags],
         current_endpoint_info[:path],
-        current_endpoint_info[:produces])
+        current_endpoint_info[:produces],
+        current_endpoint_info[:operation_id])
       settings.swagger_endpoints << endpoint
       current_endpoint_info.clear
       current_endpoint_parameters.clear

--- a/test/configuration/test-swagger-endpoint.rb
+++ b/test/configuration/test-swagger-endpoint.rb
@@ -77,11 +77,13 @@ class TestSwaggerEndpoint < Minitest::Test
         'description',
         ['tag'],
         nil,
-        ['image/gif', 'application/json']
+        ['image/gif', 'application/json'],
+        'operationId'
       ).to_swagger.must_equal(
         {
           :summary => 'summary',
           :description => 'description',
+          :operationId => 'operationId',
           :tags => ['tag'],
           :produces => ['image/gif', 'application/json'],
           :parameters => [

--- a/test/test-swagger-exposer.rb
+++ b/test/test-swagger-exposer.rb
@@ -104,6 +104,48 @@ class TestSwaggerExposer < Minitest::Test
         }, 'description [{}] should be a string')
     end
 
+    it 'should fail after a bad operationId' do
+      must_raise_swag_and_equal(
+        -> {
+          class MySinatraApp_BadOperationId < Sinatra::Base
+            register Sinatra::SwaggerExposer
+            endpoint_operation_id({})
+          end
+        }, 'operation_id [{}] should be a string')
+    end
+
+    it 'should fail after 2 operation_ids' do
+      must_raise_swag_and_equal(
+        -> {
+          class MySinatraApp_2OperationIds < Sinatra::Base
+            register Sinatra::SwaggerExposer
+            endpoint_operation_id 'getFoo'
+            endpoint_operation_id 'getBar'
+          end
+        }, 'operation_id with value [getBar] already defined: [getFoo]')
+    end
+
+    it 'should fail after a bad description' do
+      must_raise_swag_and_equal(
+        -> {
+          class MySinatraApp_BadDescription < Sinatra::Base
+            register Sinatra::SwaggerExposer
+            endpoint_description({})
+          end
+        }, 'description [{}] should be a string')
+    end
+
+    it 'should fail after 2 descriptions' do
+      must_raise_swag_and_equal(
+        -> {
+          class MySinatraApp_2Descriptions < Sinatra::Base
+            register Sinatra::SwaggerExposer
+            endpoint_description 'plap'
+            endpoint_description 'plop'
+          end
+        }, 'description with value [plop] already defined: [plap]')
+    end
+
     it 'should fail after 2 descriptions' do
       must_raise_swag_and_equal(
         -> {

--- a/test/test-utilities.rb
+++ b/test/test-utilities.rb
@@ -23,9 +23,9 @@ module TestUtilities
     Sinatra::SwaggerExposer::Configuration::SwaggerType.new(type_name, type_properties, known_types)
   end
 
-  def new_e(type, sinatra_path, parameters = [], responses = {}, summary = nil, description = nil, tags = nil, explicit_path = nil, produces = nil)
+  def new_e(type, sinatra_path, parameters = [], responses = {}, summary = nil, description = nil, tags = nil, explicit_path = nil, produces = nil, operation_id=nil)
     require_relative '../lib/sinatra/swagger-exposer/configuration/swagger-endpoint'
-    Sinatra::SwaggerExposer::Configuration::SwaggerEndpoint.new(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces)
+    Sinatra::SwaggerExposer::Configuration::SwaggerEndpoint.new(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces, operation_id)
   end
 
   def new_ep(name, description, how_to_pass, required, type, params = {}, known_types = [])


### PR DESCRIPTION
Hey,

I've been tinkering around with this gem and a small sinatra application. However, when I wanted to use the swagger-js client with my backend, I learned that swagger-js uses the operationIDs in the API to generate the javascript methods on the client. Sadly, this gem doesn't support that out of the box already.

So, I've added some things:
 - a method `endpoint_operation_id` and corresponding argument to `endpoint`. This is pretty much identical to summary or description.
 - I've added tests similar to description and summary.
 - I've documented the integration between swagger-js and sinatra-swagger-exposer, because I had to search around some to get this to work.