### PR TITLE
Allow large integer values for parameters. Fixes #11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
 addons:
   code_climate:
     repo_token: 9327b6a5a4de354ce0da555d4ae4ed262ee0fa2e4d210d8fb82511eee5a2dc2f
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/lib/sinatra/swagger-exposer/processing/swagger-primitive-value-processor.rb
+++ b/lib/sinatra/swagger-exposer/processing/swagger-primitive-value-processor.rb
@@ -65,14 +65,11 @@ module Sinatra
         # Validate an integer
         def validate_value_integer(value)
           begin
-            f = Float(value)
             i = Integer(value)
-            if f == i
-              i
-            else
+            if  i != value && value.is_a?(Float)
               raise SwaggerInvalidException.new("Value [#{name}] should be an integer but is [#{value}]")
             end
-            value = Integer(value)
+            value = i
             validate_numerical_value(value)
             value
           rescue ArgumentError

--- a/lib/sinatra/swagger-exposer/swagger-request-processor-creator.rb
+++ b/lib/sinatra/swagger-exposer/swagger-request-processor-creator.rb
@@ -75,6 +75,14 @@ module Sinatra
         elsif response_type == TYPE_FILE
           # Don't validate the files' content
           nil
+        elsif PRIMITIVE_TYPES.include? response_type
+          Sinatra::SwaggerExposer::Processing::SwaggerPrimitiveValueProcessor.new(
+            'Response',
+            true,
+            response_type,
+            nil,
+            {}
+          )
         elsif response_type
           create_processor_for_type('Response', response_type, false)
         else

--- a/test/minitest-helper.rb
+++ b/test/minitest-helper.rb
@@ -1,8 +1,5 @@
 ENV['RACK_ENV'] = 'test'
 
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'simplecov'
 SimpleCov.start do
   add_group 'lib', 'lib'

--- a/test/processing/test-swagger-primitive-value-processor.rb
+++ b/test/processing/test-swagger-primitive-value-processor.rb
@@ -52,7 +52,11 @@ class TestSwaggerPrimitiveValueProcessor < Minitest::Test
         'Value [plop] should be an integer but is [a]'
       )
 
+      # Test large integers (greater than exact float representation)
+      val = 2**53+1
+      new_pvp_and_run('plop', TYPE_INTEGER, val).must_equal val
       new_pvp_and_run('plop', TYPE_INTEGER, '123').must_equal 123
+      new_pvp_and_run('plop', TYPE_INTEGER, val.to_s).must_equal val
 
       must_raise_swag_and_equal(
         -> { new_pvp_and_run('plop', TYPE_INTEGER, 123.45) },


### PR DESCRIPTION
Only compares float values to the integer for exact match. Integers over 2^53 which aren't powers of 2 don't have an exact representation as a float.